### PR TITLE
Fix 'cargo build' cannot compile after cloning the repository.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 version = "*"
 
 [dependencies.mio]
-version = "*"
+git = "https://github.com/carllerche/mio"
 


### PR DESCRIPTION
This pull request intends to fix that `cargo build` command cannot compile after cloning the repository.

The specified dependency pulls the old version of mio from crates.io because the latest mio don't published in crates.io. This causes the above problem.

We use mio's repository directly until the latest version is published in crates.io.
