### PR TITLE
Fixes for nightly

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -17,7 +17,7 @@ pub struct ClosureHandler<I, R, W> {
     pub opt: Option<PollOpt>
 }
 
-impl<I, R, W> Handler for ClosureHandler<I, R, W>
+impl<I: 'static, R: 'static, W: 'static> Handler for ClosureHandler<I, R, W>
 where I: Send + IoHandle,
       R: Send + FnMut(&mut I, ReadHint) -> bool,
       W: Send + FnMut(&mut I) -> bool {

--- a/src/ioloop.rs
+++ b/src/ioloop.rs
@@ -34,10 +34,10 @@ impl IoLoop {
     }
 
     pub fn run(&mut self) -> EventResult<()> {
-        match self.events.run(self.handler.take().unwrap()) {
+        match self.events.run(&mut self.handler.take().unwrap()) {
             Ok(..) => Ok(()),
             Err(err) => {
-                Err(EventError::MioError(err.error))
+                Err(EventError::MioError(err))
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,13 @@ pub fn next<F: FnOnce() + 'static>(callback: F) -> Result<(), ()> {
     apply_events(move |events| events.next(callback))
 }
 
-pub fn interval<F: FnMut() + Send>(callback: F, delay: Duration) {
+pub fn interval<F: 'static + FnMut() + Send>(callback: F, delay: Duration) {
     struct Interval<F> {
         callback: F,
         delay: Duration
     }
 
-    impl<F: FnMut() + Send()> FnOnce<()> for Interval<F> {
+    impl<F: 'static + FnMut() + Send()> FnOnce<()> for Interval<F> {
         type Output = ();
 
         extern "rust-call" fn call_once(mut self, _: ()) {


### PR DESCRIPTION
Hi,

This PR fixes some issues I've noticed while running the last nightly (`rustc 1.0.0-nightly (dfc5c0f1e 2015-02-18) (built 2015-02-19)`). I don't fully understand the changes I've applied (mainly the `'static` ones), however the examples seem to run fine.

SK on IRC indicated that the `'static` issue might be linked to rust-lang/rust#22319, which landed recently.

Please let me know if you'd like some more tests.
